### PR TITLE
XIVY-14735 new slim endpoints using json in/output :camping: 

### DIFF
--- a/docker/mariadb/00_init.sql
+++ b/docker/mariadb/00_init.sql
@@ -1,3 +1,16 @@
+CREATE TABLE ProductLog
+(
+   Id bigint PRIMARY KEY AUTO_INCREMENT NOT NULL,
+   `Timestamp` datetime NOT NULL,
+   `Version` varchar(50) NOT NULL,
+   Product varchar(10) NOT NULL,
+   `Usage` TEXT NOT NULL
+) 
+ENGINE=InnoDB 
+DEFAULT CHARSET=UTF8 
+COLLATE utf8_general_ci;
+
+
 CREATE TABLE EngineLog
 (
    Id bigint PRIMARY KEY AUTO_INCREMENT NOT NULL,
@@ -75,6 +88,8 @@ CREATE TABLE DesignerLog
 
 ALTER TABLE EngineLog AUTO_INCREMENT=300000;
 ALTER TABLE DesignerLog AUTO_INCREMENT=300000;
+ALTER TABLE ProductLog AUTO_INCREMENT=300000;
 
 ALTER TABLE EngineLog ADD COLUMN HttpRequestIpAddress varchar(255) NULL;
 ALTER TABLE DesignerLog ADD COLUMN HttpRequestIpAddress varchar(255) NULL;
+ALTER TABLE ProductLog ADD COLUMN HttpRequestIpAddress varchar(255) NULL;

--- a/src/app/Application.php
+++ b/src/app/Application.php
@@ -5,11 +5,16 @@ use PDO;
 use Slim\App;
 use DI\Container;
 use axonivy\update\controller\CallingHomeController;
+use axonivy\update\controller\CallingHomeControllerV2;
 use axonivy\update\repository\DesignerLogRepository;
 use axonivy\update\repository\EngineLogRepository;
 use axonivy\update\repository\ReleaseInfoRepository;
 use axonivy\update\controller\HomePageController;
+use axonivy\update\repository\ProductLogRepository;
 use Slim\Factory\AppFactory;
+
+use Slim\Psr7\Request as Psr7Request;
+use Slim\Psr7\Response as Psr7Response;
 
 class Application
 {
@@ -31,8 +36,9 @@ class Application
         
         $app->post('/ivy/pro/UpdateService/UpdateService/141746D7E212F6D2/designer.ivp', CallingHomeController::class . ':designer');
         $app->post('/ivy/pro/UpdateService/UpdateService/141746D7E212F6D2/server.ivp', CallingHomeController::class . ':engine');
+        $app->post('/api/update/product', CallingHomeControllerV2::class . ':product');
         $app->get('/', HomePageController::class);
-        
+
         return $app;
     }
 
@@ -63,6 +69,13 @@ class Application
             $engineLogRepo = new EngineLogRepository($db);
             $releaseInfoRepo = new ReleaseInfoRepository($config['settings']['developerAPI']);
             return new CallingHomeController($designerLogRepo, $engineLogRepo, $releaseInfoRepo);
+        });
+    
+        $container->set(CallingHomeControllerV2::class, function (Container $container) use ($config) {
+            $db = $container->get('db');
+            $productLogRepo = new ProductLogRepository($db);
+            $releaseInfoRepo = new ReleaseInfoRepository($config['settings']['developerAPI']);
+            return new CallingHomeControllerV2($productLogRepo, $releaseInfoRepo);
         });
 
         return $container;

--- a/src/app/Application.php
+++ b/src/app/Application.php
@@ -13,8 +13,6 @@ use axonivy\update\controller\HomePageController;
 use axonivy\update\repository\ProductLogRepository;
 use Slim\Factory\AppFactory;
 
-use Slim\Psr7\Request as Psr7Request;
-use Slim\Psr7\Response as Psr7Response;
 
 class Application
 {

--- a/src/app/controller/CallingHomeControllerV2.php
+++ b/src/app/controller/CallingHomeControllerV2.php
@@ -20,7 +20,7 @@ class CallingHomeControllerV2
         $this->releaseInfoRepo = $releaseInfoRepo;
     }
 
-    public function product(Request $request, Response $response)
+    public function product(Request $request, Response $response): Response
     {
         $payload = json_decode($request->getBody());
         $name = $payload->IvyProduct->name;
@@ -33,7 +33,7 @@ class CallingHomeControllerV2
         return $this->respond($response, $info);
     }
 
-    private function ipAddress()
+    private function ipAddress(): string
     {
         return $_SERVER['REMOTE_ADDR'] ?? ''; // or use a middleware to get the ip
     }
@@ -45,9 +45,9 @@ class CallingHomeControllerV2
         return $info;
     }
     
-    private function respond(Response $response, $releaseInfo)
+    private function respond(Response $response, $releaseInfo): Response
     {
-        $json= json_encode($releaseInfo);
+        $json = json_encode($releaseInfo);
         $response->getBody()->write($json);
         $response->withAddedHeader('Expires', 0);
         return $response;

--- a/src/app/controller/CallingHomeControllerV2.php
+++ b/src/app/controller/CallingHomeControllerV2.php
@@ -1,0 +1,55 @@
+<?php
+namespace axonivy\update\controller;
+
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Message\ResponseInterface as Response;
+
+use axonivy\update\repository\ProductLogRepository;
+use axonivy\update\repository\ReleaseInfoRepository;
+use axonivy\update\model\ProductLogRecord;
+
+
+class CallingHomeControllerV2
+{
+    private ProductLogRepository $productLogRepo;
+    private ReleaseInfoRepository $releaseInfoRepo;
+
+    public function __construct(ProductLogRepository $productLogRepo, ReleaseInfoRepository $releaseInfoRepo)
+    {
+        $this->productLogRepo = $productLogRepo;
+        $this->releaseInfoRepo = $releaseInfoRepo;
+    }
+
+    public function product(Request $request, Response $response)
+    {
+        $payload = json_decode($request->getBody());
+        $name = $payload->IvyProduct->name;
+        $version = $payload->IvyProduct->version;
+
+        $record = new ProductLogRecord(time(), $this->ipAddress(), $name, $version, json_encode($payload));
+        $this->productLogRepo->write($record);
+        
+        $info = $this->releaseInfo($version);
+        return $this->respond($response, $info);
+    }
+
+    private function ipAddress()
+    {
+        return $_SERVER['REMOTE_ADDR'] ?? ''; // or use a middleware to get the ip
+    }
+
+    private function releaseInfo($version) 
+    {
+        $info = $this->releaseInfoRepo->getCurrentReleaseInfo($version);
+        $info->url='https://developer.axonivy.com/download/';
+        return $info;
+    }
+    
+    private function respond(Response $response, $releaseInfo)
+    {
+        $json= json_encode($releaseInfo);
+        $response->getBody()->write($json);
+        $response->withAddedHeader('Expires', 0);
+        return $response;
+    }
+}

--- a/src/app/model/ProductLogRecord.php
+++ b/src/app/model/ProductLogRecord.php
@@ -3,14 +3,13 @@ namespace axonivy\update\model;
 
 class ProductLogRecord
 {
-    private $id;
-    private $timestamp;
-    private $ipAddress;
-    private $product;
-    private $version;
-    private $usage;
+    private int $timestamp;
+    private string $ipAddress;
+    private string $product;
+    private string $version;
+    private string $usage;
 
-    public function __construct($timestamp, string $ipAddress, string $product, string $version, string $usage)
+    public function __construct(int $timestamp, string $ipAddress, string $product, string $version, string $usage)
     {
         $this->timestamp = $timestamp;
         $this->ipAddress = $ipAddress;
@@ -18,38 +17,28 @@ class ProductLogRecord
         $this->version = $version;
         $this->usage = $usage;
     }
-
-    public function getId()
-    {
-        return $this->id;
-    }
-
-    public function setId($id)
-    {
-        $this->id = $id;
-    }
     
-    public function getIpAddress()
+    public function getIpAddress(): string
     {
         return $this->ipAddress;
     }
 
-    public function getTimestamp()
+    public function getTimestamp(): int
     {
         return $this->timestamp;
     }
 
-    public function getProduct()
+    public function getProduct(): string
     {
         return $this->product;
     }
 
-    public function getVersion()
+    public function getVersion(): string
     {
         return $this->version;
     }
 
-    public function getUsage()
+    public function getUsage(): string
     {
         return $this->usage;
     }

--- a/src/app/model/ProductLogRecord.php
+++ b/src/app/model/ProductLogRecord.php
@@ -1,0 +1,57 @@
+<?php
+namespace axonivy\update\model;
+
+class ProductLogRecord
+{
+    private $id;
+    private $timestamp;
+    private $ipAddress;
+    private $product;
+    private $version;
+    private $usage;
+
+    public function __construct($timestamp, string $ipAddress, string $product, string $version, string $usage)
+    {
+        $this->timestamp = $timestamp;
+        $this->ipAddress = $ipAddress;
+        $this->product = $product;
+        $this->version = $version;
+        $this->usage = $usage;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+    
+    public function getIpAddress()
+    {
+        return $this->ipAddress;
+    }
+
+    public function getTimestamp()
+    {
+        return $this->timestamp;
+    }
+
+    public function getProduct()
+    {
+        return $this->product;
+    }
+
+    public function getVersion()
+    {
+        return $this->version;
+    }
+
+    public function getUsage()
+    {
+        return $this->usage;
+    }
+
+}

--- a/src/app/repository/ProductLogRepository.php
+++ b/src/app/repository/ProductLogRepository.php
@@ -13,7 +13,8 @@ class ProductLogRepository
         $this->pdo = $pdo;
     }
 	
-	public function write(ProductLogRecord $record) {
+	public function write(ProductLogRecord $record): void
+	{
 		$stmt = $this->pdo->prepare('INSERT INTO ProductLog (
 			`Timestamp`,
             HttpRequestIpAddress,

--- a/src/app/repository/ProductLogRepository.php
+++ b/src/app/repository/ProductLogRepository.php
@@ -1,0 +1,38 @@
+<?php
+namespace axonivy\update\repository;
+
+use PDO;
+use axonivy\update\model\ProductLogRecord;
+
+class ProductLogRepository
+{
+    private $pdo;
+
+    public function __construct($pdo)
+    {
+        $this->pdo = $pdo;
+    }
+	
+	public function write(ProductLogRecord $record) {
+		$stmt = $this->pdo->prepare('INSERT INTO ProductLog (
+			`Timestamp`,
+            HttpRequestIpAddress,
+			Product,
+			`Version`,
+			`Usage`
+		) VALUES (
+			:Timestamp,
+            :HttpRequestIpAddress,
+			:Product,
+			:Version,
+			:Usage
+		)');
+		
+		$stmt->bindValue(':Timestamp', date('Y-m-d H:i:s', $record->getTimestamp()));
+		$stmt->bindValue(':HttpRequestIpAddress', $record->getIpAddress());
+		$stmt->bindValue(':Product', $record->getProduct());
+		$stmt->bindValue(':Version', $record->getVersion());
+		$stmt->bindValue(':Usage', $record->getUsage());
+		$stmt->execute();
+	}
+}

--- a/test/integration/controller/CallingHomeControllerV2Test.php
+++ b/test/integration/controller/CallingHomeControllerV2Test.php
@@ -1,0 +1,84 @@
+<?php
+use axonivy\update\Application;
+use Slim\Psr7\Factory\RequestFactory;
+use Slim\Psr7\Response;
+use Slim\App;
+use Slim\Psr7\Factory\StreamFactory;
+
+require_once 'IntegrationTestCase.php';
+
+final class CallingHomeControllerV2Test extends IntegrationTestCase
+{
+    public function testUpdateJsonEngine(): void 
+    {
+        $usage = '{ 
+            "Java" : {  
+                "version" : "21.0.3",
+                "vendor": "Eclipse Adoptium"
+            },
+            "Network" : {
+                "hostName" : "zugnbrew",
+                "ipAddress" : "1234354354343"
+            },
+            "IvyProduct" : {
+                "name" : "Engine",
+                "version" : "10.0.19"
+            }
+        }';
+
+        $response = $this->fireRequest('/api/update/product', $usage);
+        $latest = json_decode($response->getBody());
+
+        $this->assertVersionNumber($latest->latestReleaseVersion);
+        $this->assertVersionNumber($latest->latestServiceReleaseVersion);
+        $this->assertEquals('https://developer.axonivy.com/download/', $latest->url);
+    }
+
+    public function testUpdateJsonDesigner(): void 
+    {
+        $usage = '{ 
+            "IvyProduct" : {
+                "name" : "Designer",
+                "version" : "10.0.19"
+            }
+        }';
+
+        $response = $this->fireRequest('/api/update/product', $usage);
+        $latest = json_decode($response->getBody());
+
+        $this->assertVersionNumber($latest->latestReleaseVersion);
+        $this->assertVersionNumber($latest->latestServiceReleaseVersion);
+        $this->assertEquals('https://developer.axonivy.com/download/', $latest->url);
+    }
+
+    private function fireRequest(String $url, String $json): Response
+    {
+        $payload = (new StreamFactory())->createStream($json);
+        $request = (new RequestFactory())
+            ->createRequest('POST', $url)
+            ->withBody($payload)
+            ->withHeader('Content-Type', 'application/json');
+        return $this->app()->handle($request);
+    }
+    
+    private function app(): App
+    {
+        $configuration = [
+            'settings' => [
+                'displayErrorDetails' => true,
+                'db' => $this->dbConfig,
+                'developerAPI' => 'https://developer.axonivy.com/api'
+            ]
+        ];
+        return (new Application())->createApp($configuration);
+    }
+    
+    private function assertVersionNumber($version)
+    {
+        $this->assertEquals(-1, version_compare(5, $version));
+        $parts = explode('.', $version);
+        $this->assertTrue(is_numeric($parts[0]));
+        $this->assertTrue(is_numeric($parts[1]));
+        $this->assertTrue(is_numeric($parts[2]));
+    }
+}

--- a/test/testdata/testdata.sql
+++ b/test/testdata/testdata.sql
@@ -1,3 +1,10 @@
+INSERT INTO ProductLog 
+( Id, `Timestamp`, Product, `Version`, `Usage` ) 
+VALUES 
+( 23, '2024-08-19 16:06:44', 'Designer', '10.0.19', '{"Java" : {"version": "21.0.3" }}'),
+( 24, '2024-08-20 11:42:44', 'Engine', '11.3.1', '{"Java" : {"version": "17.0.9" }}'),
+;
+
 INSERT INTO DesignerLog (
 		Id,
 		Timestamp,


### PR DESCRIPTION
introduce the new endpoint that accepts JSON, and does no heavy parsing of the usage-stats payload ... instead we just pass it through and store in the DB.
the existing endpoints remain untouched ... they can serve the old releases as long as we want.